### PR TITLE
add PlantUml writer and auto-generate in state-machine-maven-plugin

### DIFF
--- a/state-machine-generator/src/main/java/com/github/davidmoten/fsm/graph/PlantUmlWriter.java
+++ b/state-machine-generator/src/main/java/com/github/davidmoten/fsm/graph/PlantUmlWriter.java
@@ -1,0 +1,48 @@
+package com.github.davidmoten.fsm.graph;
+
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class PlantUmlWriter {
+
+    public void print(PrintWriter out, Graph graph, Function<GraphNode, NodeOptions> options,
+            boolean includeDocumentation) {
+
+        out.println("@startuml");
+        out.println();
+
+        if (includeDocumentation) {
+            graph //
+                    .getNodes() //
+                    .stream() //
+                    .filter(x -> !x.state().isInitial()) //
+                    .forEach(x -> {
+                        Arrays.stream(x.state().documentation().orElse("").split("\n")) //
+                                .map(y -> y.trim()) //
+                                .map(y -> x.state().name() + ":" + y) //
+                                .forEach(out::println);
+                    });
+        }
+
+        graph //
+                .getEdges() //
+                .stream() //
+                .forEach(x -> {
+                    if (x.getFrom().state().isInitial()) {
+                        out.println("[*] --> " + x.getTo().state().name() + " : "
+                                + x.getTo().state().eventClass().getSimpleName());
+                    } else {
+                        out.println(x.getFrom().state().name() + " --> " + x.getTo().state().name()
+                                + " : " + x.getTo().state().eventClass().getSimpleName());
+                    }
+                });
+
+        out.println();
+        out.println("@enduml");
+
+    }
+
+}

--- a/state-machine-generator/src/main/java/com/github/davidmoten/fsm/graph/PlantUmlWriter.java
+++ b/state-machine-generator/src/main/java/com/github/davidmoten/fsm/graph/PlantUmlWriter.java
@@ -2,9 +2,7 @@ package com.github.davidmoten.fsm.graph;
 
 import java.io.PrintWriter;
 import java.util.Arrays;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public final class PlantUmlWriter {
 
@@ -20,9 +18,9 @@ public final class PlantUmlWriter {
                     .stream() //
                     .filter(x -> !x.state().isInitial()) //
                     .forEach(x -> {
-                        Arrays.stream(x.state().documentation().orElse("").split("\n")) //
+                        Arrays.stream(x.state().documentation().orElse("").replaceAll("<.+>","").split("\n")) //
                                 .map(y -> y.trim()) //
-                                .map(y -> x.state().name() + ":" + y) //
+                                .map(y -> name(x.state().name()) + ":" + y) //
                                 .forEach(out::println);
                     });
         }
@@ -32,10 +30,10 @@ public final class PlantUmlWriter {
                 .stream() //
                 .forEach(x -> {
                     if (x.getFrom().state().isInitial()) {
-                        out.println("[*] --> " + x.getTo().state().name() + " : "
+                        out.println("[*] --> " + name(x.getTo().state().name()) + " : "
                                 + x.getTo().state().eventClass().getSimpleName());
                     } else {
-                        out.println(x.getFrom().state().name() + " --> " + x.getTo().state().name()
+                        out.println(name(x.getFrom().state().name()) + " --> " + name(x.getTo().state().name())
                                 + " : " + x.getTo().state().eventClass().getSimpleName());
                     }
                 });
@@ -43,6 +41,10 @@ public final class PlantUmlWriter {
         out.println();
         out.println("@enduml");
 
+    }
+    
+    private static String name(String name) {
+        return name.replaceAll(" ", "_");
     }
 
 }

--- a/state-machine-generator/src/main/java/com/github/davidmoten/fsm/graph/PlantUmlWriter.java
+++ b/state-machine-generator/src/main/java/com/github/davidmoten/fsm/graph/PlantUmlWriter.java
@@ -18,7 +18,7 @@ public final class PlantUmlWriter {
                     .stream() //
                     .filter(x -> !x.state().isInitial()) //
                     .forEach(x -> {
-                        Arrays.stream(x.state().documentation().orElse("").replaceAll("<.+>","").split("\n")) //
+                        Arrays.stream(x.state().documentation().orElse("").replaceAll("<[^>]+>","").split("\n")) //
                                 .map(y -> y.trim()) //
                                 .map(y -> name(x.state().name()) + ":" + y) //
                                 .forEach(out::println);

--- a/state-machine-generator/src/test/java/com/github/davidmoten/fsm/model/StateMachineTest.java
+++ b/state-machine-generator/src/test/java/com/github/davidmoten/fsm/model/StateMachineTest.java
@@ -2,10 +2,37 @@ package com.github.davidmoten.fsm.model;
 
 import org.junit.Test;
 
+import com.github.davidmoten.fsm.graph.NodeOptions;
+import com.github.davidmoten.fsm.runtime.Event;
+
 public class StateMachineTest {
 
     @Test
-    public void test() {
+    public void testPlantUmlGeneration() {
+
+        StateMachineDefinition<Person> m = StateMachineDefinition.create(Person.class);
+        State<Person, Illness> sick = m.createState("Sick").event(Illness.class).documentation("has an illness");
+        State<Person, Health> well = m.createState("Well").event(Health.class);
+        State<Person, Dies> dead = m.createState("Dead").event(Dies.class).documentation("not alive\nready for burial");
+        
+        m.addInitialTransition(well);
+        well.from(sick).to(sick).to(dead);
+        System.out.println(m.plantuml(g -> NodeOptions.defaultInstance(), true));
+    }
+
+    private static final class Person {
+
+    }
+
+    private static final class Illness implements Event<Person> {
+
+    }
+
+    private static final class Health implements Event<Person> {
+
+    }
+
+    private static final class Dies implements Event<Person> {
 
     }
 

--- a/state-machine-maven-plugin/src/main/java/com/github/davidmoten/fsm/maven/GeneratorMojo.java
+++ b/state-machine-maven-plugin/src/main/java/com/github/davidmoten/fsm/maven/GeneratorMojo.java
@@ -55,6 +55,10 @@ public class GeneratorMojo extends AbstractMojo {
             generateGraphml(machine, true);
             // without docs
             generateGraphml(machine, false);
+            // with docs
+            generatePlantUml(machine, true);
+            // without docs
+            generatePlantUml(machine, false);
             generateHtml(machine);
         }
         getLog().info("generated classes in " + outputDirectory + " with package " + packageName);
@@ -87,6 +91,18 @@ public class GeneratorMojo extends AbstractMojo {
             throw new RuntimeException(e);
         }
         getLog().info("generated graphml file for import to yed (for instance): " + gml);
+    }
+    
+    private void generatePlantUml(StateMachineDefinition<?> machine, boolean includeDocumentation) {
+        diagramsDirectory.mkdirs();
+        File uml = new File(diagramsDirectory, machine.cls().getCanonicalName().replace("$", ".")
+                + (includeDocumentation ? "-with-docs" : "") + ".plantuml");
+        try (PrintWriter out = new PrintWriter(uml)) {
+            out.println(machine.plantuml(node -> NodeOptions.defaultInstance(), includeDocumentation));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        getLog().info("generated plantUml file: " + uml);
     }
 
     private String value(StateMachineDefinition<?> machine, String key, String defaultValue) {

--- a/state-machine-test-definition/src/test/java/com/github/davidmoten/fsm/example/StateMachineDefinitionsTest.java
+++ b/state-machine-test-definition/src/test/java/com/github/davidmoten/fsm/example/StateMachineDefinitionsTest.java
@@ -1,0 +1,18 @@
+package com.github.davidmoten.fsm.example;
+
+import org.junit.Test;
+
+import com.github.davidmoten.fsm.graph.NodeOptions;
+import com.github.davidmoten.fsm.model.StateMachineDefinition;
+
+public class StateMachineDefinitionsTest {
+
+    @Test
+    public void testPlantUml() {
+
+        for (StateMachineDefinition<?> s: new StateMachineDefinitions().get()) {
+            System.out.println(s.plantuml(g -> NodeOptions.defaultInstance(), true));
+        }
+    }
+
+}

--- a/state-machine-test/src/test/java/com/github/davidmoten/fsm/StateMachineTest.java
+++ b/state-machine-test/src/test/java/com/github/davidmoten/fsm/StateMachineTest.java
@@ -45,5 +45,5 @@ public class StateMachineTest {
         assertEquals(m.state(), MicrowaveStateMachine.State.COOKING_INTERRUPTED);
         assertEquals(MicrowaveStateMachine.State.COOKING, m.previousState().get());
     }
-
+    
 }


### PR DESCRIPTION
As discussed in #12 this PR adds the ability to write a StateMachineDefinition in plantuml format.

Here's the Microwave example using online PlantUML editor:

![img](https://user-images.githubusercontent.com/318187/99494307-e52a1000-29c4-11eb-982f-e93d5cc5e34c.png)

Markup tags are automatically removed from the documentation and underscores inserted into state names (PlantUML doesn't allow spaces in state names). The name cleanup could be improved to use camel-case where obvious.